### PR TITLE
Remove erroneous asset exclusions from .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,3 @@
 node_modules
-build
-config
-docs
-src
-index.html
 .DS_Store
 .*


### PR DESCRIPTION
There's no need to exclude the src and docs files from the distribution. Oftentimes these are useful when locally extending a package with locally custom features.